### PR TITLE
chore(plugins): add accepting configurable plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,5 @@
-# :warning: No Longer Supported :warning:
-
-**We will not be making changes, accepting pull requests, or cutting new versions of this repository.**
-
-We no longer recommend using this repository as it does not promote best practices.
-
-- While it makes it easier by loading in all of the models in a directory, it adds a bit of magic to the loading process that should be left explicit.
-- It makes it harder to reference these models once you start fleshing out your codebase i.e. pulling your code into separate files. For you to be able to access any of your models in another file, you'll need to have access to the `server` object so you'll have to pass that around, even though you don't need the entire object.
-- We don't actively maintain this repo since we don't really use it ourselves anymore.
-- The [Bookshelf registry plugin](https://github.com/tgriesser/bookshelf/wiki/Plugin:-Model-Registry) is required when using this modules, but if you don't actually need it (i.e. you don't have circular dependencies with your models), then it just adds unnecessary complexity to your project.
-- The creator of Hapi [frowns upon](https://gist.github.com/hueniverse/f01faf422eb038d87d57#when-should-i-not-use-multiple-plugins) using plugins in this manner.
-
-Instead, we recommend just `require`ing the models as you need them. That way, you can easily refer to the models and only include the ones that make sense to have in the current context.
 
 # Hapi Bookshelf Models
-[![Build Status](https://travis-ci.org/lob/hapi-bookshelf-models.svg)](https://travis-ci.org/lob/hapi-bookshelf-models)
-[![Coverage Status](https://coveralls.io/repos/lob/hapi-bookshelf-models/badge.svg?branch=master)](https://coveralls.io/r/lob/hapi-bookshelf-models?branch=master)
-[![NPM version](https://badge.fury.io/js/hapi-bookshelf-models.svg)](https://npmjs.org/package/hapi-bookshelf-models)
-[![Downloads](http://img.shields.io/npm/dm/hapi-bookshelf-models.svg)](https://npmjs.org/package/hapi-bookshelf-models)
-
 
 The purpose of this plugin is to provide a convenient way to register [Bookshelf.js](http://bookshelfjs.org/) models and expose them via a [Hapi](http://hapijs.com/) plugin.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,10 @@ exports.register = function (server, options, next) {
 
   var schema = {
     knex: Joi.object().required(),
-    plugins: Joi.array().items(Joi.string()).default([]),
+    plugins: Joi.array().items([Joi.string(), Joi.object({
+      name: Joi.string().required(),
+      options: Joi.object().optional()
+    })]).default([]),
     models: Joi.array().items(Joi.string()).single().default([]),
     collections: Joi.array().items(Joi.string()).single().default([]),
     base: Joi.alternatives().try(Joi.func(), Joi.object({
@@ -36,7 +39,11 @@ exports.register = function (server, options, next) {
   }
 
   options.plugins.map(function (plugin) {
-    bookshelf.plugin(plugin);
+    if (typeof plugin === 'string') {
+      bookshelf.plugin(plugin);
+    } else {
+      bookshelf.plugin(plugin.name, plugin.options);
+    }
   });
 
   var baseModel;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "hapi-bookshelf-models",
+  "name": "hapi-bookshelf-models2",
   "version": "2.0.0",
   "description": "Hapi Plugin to Register Bookshelf Models",
   "main": "lib/index.js",
@@ -14,18 +14,18 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/lob/hapi-bookshelf-models.git"
+    "url": "https://github.com/Do-IT-Programming-Solutions-LP/hapi-bookshelf-models2.git"
   },
   "keywords": [
     "hapi",
     "bookshelf"
   ],
-  "author": "Peter Nagel <peter@lob.com>",
+  "author": "Max Rostov <ktulchonok@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/lob/hapi-bookshelf-models/issues"
+    "url": "https://github.com/Do-IT-Programming-Solutions-LP/hapi-bookshelf-models2/issues"
   },
-  "homepage": "https://github.com/lob/hapi-bookshelf-models",
+  "homepage": "https://github.com/Do-IT-Programming-Solutions-LP/hapi-bookshelf-models2",
   "dependencies": {
     "glob": "^5.0.15",
     "joi": "^6.10.1"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -70,7 +70,7 @@ describe('bookshelf plugin', function () {
     });
   });
 
-  it('should load a good configuration', function () {
+  it('should load a good configuration with plugin as string', function () {
     var server = new Hapi.Server();
 
     server.register([
@@ -85,6 +85,38 @@ describe('bookshelf plugin', function () {
             }
           },
           plugins: ['registry'],
+          models: path.join(__dirname + '/models'),
+          base: function (bookshelf) {
+            return bookshelf.Model.extend({
+              test: 'test'
+            });
+          }
+        }
+      }
+    ], function (err) {
+      expect(err).to.be.undefined;
+      expect(server.plugins.bookshelf.model('User')).to.be.a('function');
+      expect(server.plugins.bookshelf.model('Role')).to.be.undefined;
+      var User = server.plugins.bookshelf.model('User').forge({ id: 1 });
+      expect(User.test).to.eql('test');
+    });
+  });
+
+  it('should load a good configuration with plugin as object', function () {
+    var server = new Hapi.Server();
+
+    server.register([
+      {
+        register: require('../lib/'),
+        options: {
+          knex: {
+            client: 'sqlite3',
+            useNullAsDefault: true,
+            connection: {
+              filename: './database.sqlite'
+            }
+          },
+          plugins: [{ name: 'registry' }],
           models: path.join(__dirname + '/models'),
           base: function (bookshelf) {
             return bookshelf.Model.extend({


### PR DESCRIPTION
lob/hapi-bookshelf-models is decommissioned.
Forked it as hapi-bookshelf-models2 to publish as hapi-bookshelf-models2 npm.